### PR TITLE
Adding double quotes to string in json sqs message

### DIFF
--- a/pkg/api/aws_api.go
+++ b/pkg/api/aws_api.go
@@ -219,7 +219,7 @@ func sendSqsMessage(instanceID string) bool {
 
 	message := &sqs.SendMessageInput{
 		DelaySeconds: aws.Int64(5),
-		MessageBody:  aws.String(`{ "detail-type": "Spot Ninja Notification Drain", "source": "spot-ninja", "detail": { "instance-id": ` + instanceID + `, "state": "terminated" } }`),
+		MessageBody:  aws.String(`{ "detail-type": "Spot Ninja Notification Drain", "source": "spot-ninja", "detail": { "instance-id": "` + instanceID + `", "state": "terminated" } }`),
 		QueueUrl:     &qURL,
 	}
 	_, err := client.SendMessage(message)


### PR DESCRIPTION
**Problem:**
SQS message is not being processed by `ecs-drainer`

**How to reproduce**
All ecs container instance supoused to be dreaned, is resuting in an error.


