### PR TITLE
Panic fix - pt²

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -263,7 +263,7 @@ func TestTimeToLive(t *testing.T) {
 	}{
 		{"Test", 900},
 	}
-	
+
 	result := TimeToLive()
 
 	for _, tt := range tests {

--- a/pkg/api/aws_api.go
+++ b/pkg/api/aws_api.go
@@ -61,7 +61,6 @@ func GetSpotID(client ec2iface.EC2API) []string {
 
 // QueryDataRequest request all necessary data from AWS
 func QueryDataRequest(data *cloudwatch.MetricDataQuery) int64 {
-	var result float64
 	client := sessionStartCloudWatch()
 
 	timeNow := time.Now()
@@ -80,18 +79,12 @@ func QueryDataRequest(data *cloudwatch.MetricDataQuery) int64 {
 		fmt.Println("error, describe-metadata, ", err)
 	}
 
-	if len(dataResult.MetricDataResults) == 0 {
-		fmt.Println("error, describe-metadata, metadata are empty")
-		return 0
-	}
-
-	for _, loop := range dataResult.MetricDataResults {
-		result = *loop.Values[0]
-	}
+	result := *dataResult.MetricDataResults[0].Values[0]
 
 	if result >= 1 {
 		return int64(result) / structure.Divider()
 	}
+
 	return 0
 }
 

--- a/pkg/api/aws_api.go
+++ b/pkg/api/aws_api.go
@@ -79,8 +79,12 @@ func QueryDataRequest(data *cloudwatch.MetricDataQuery) int64 {
 		fmt.Println("error, describe-metadata, ", err)
 	}
 
-	result := *dataResult.MetricDataResults[0].Values[0]
+	// avoid index out of range
+	if len(fmt.Sprint(*dataResult.MetricDataResults[0].Values[0])) == 0 {
+		return 0
+	}
 
+	result := *dataResult.MetricDataResults[0].Values[0]
 	if result >= 1 {
 		return int64(result) / structure.Divider()
 	}

--- a/pkg/api/aws_api.go
+++ b/pkg/api/aws_api.go
@@ -77,10 +77,16 @@ func QueryDataRequest(data *cloudwatch.MetricDataQuery) int64 {
 	dataResult, err := client.GetMetricData(request)
 	if err != nil {
 		fmt.Println("error, describe-metadata, ", err)
+		return 0
 	}
 
-	// avoid index out of range
-	if len(fmt.Sprint(*dataResult.MetricDataResults[0].Values[0])) == 0 {
+	if len(dataResult.MetricDataResults) == 0 {
+		fmt.Println("error, describe-metadata, MetricDataResults empty")
+		return 0
+	}
+
+	if len(dataResult.MetricDataResults[0].Values) == 0 {
+		fmt.Println("error, describe-metadata, MetricDataResults.Values empty")
 		return 0
 	}
 


### PR DESCRIPTION
Verifying that _MetricDataResults_ == _empty_  not worked:
![image](https://user-images.githubusercontent.com/44173269/63358732-e8f26100-c341-11e9-8ee2-42adc34272ce.png)

 Also, not necessary to use a _loop_. 
I just need to look at the single Query datapoint.

I am removing the loop and checking the size of the slice result.
I needed to use fmt.sprint to convert float > string